### PR TITLE
Remove restriction on branches for PR build

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -8,8 +8,6 @@ on:
     tags:
       - "v*"
   pull_request:
-    branches:
-      - main
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/Changelog
+++ b/Changelog
@@ -1,6 +1,6 @@
 Version 0.2.8     unreleased
 
-	* Pull in latest version of run-script-framework.
+	* Adjust GHA build process to allow builds for stacked PRs.
 	* Upgrade to poetry-dynamic-versioning v1.5.2 for minor fixes.
 	* Add .python-version in preferred order to support pyenv.
 	* Fix problem with relative test imports using Pycharm on Linux.


### PR DESCRIPTION
I want to be able to stack pull requests, and the current GitHub Actions workflow prevents builds from happening on stacked PRs.  Prototyped in [apologies PR #70](https://github.com/pronovic/apologies/pull/70).