### PR TITLE
Update the MyPy configuration so we're using latest rules

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -6,6 +6,7 @@ Version 0.2.8     unreleased
 	* Adjust GHA build process to allow builds for stacked PRs.
 	* Add a new `run clean` target to clean up generated data.
 	* Move unit tests from `tests` into `src/tests/reorder`.
+	* Update the MyPy configuration so we're using latest rules.
 
 Version 0.2.7     08 Jan 2025
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,12 +104,12 @@ filterwarnings = [
 ]
 
 [tool.mypy]
-# Settings are mostly equivalent to strict=true as of v1.14.1
+files = [ "src" ]
 pretty = true
 show_absolute_path = true
 show_column_numbers = true
 show_error_codes = true
-files = [ "src" ]
+# Settings equivalent to strict=true as of v1.17.1
 check_untyped_defs = true
 disallow_any_generics = true
 disallow_incomplete_defs = true
@@ -117,15 +117,18 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = false
 disallow_untyped_defs = true
-no_implicit_optional = true
+extra_checks = true
 no_implicit_reexport = true
 strict_equality = true
-strict_optional = true
 warn_redundant_casts = true
 warn_return_any = true
-warn_no_return = true
 warn_unused_configs = true
 warn_unused_ignores = true
+# Additional settings above and beyond strict=true
+implicit_optional = false
+strict_optional = true
+warn_no_return = true
+warn_unreachable = true
 
 # It's hard to make tests compliant using unittest.mock
 [[tool.mypy.overrides]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -135,8 +135,3 @@ warn_unreachable = true
 module = "tests.*"
 check_untyped_defs = false
 allow_untyped_defs = true
-
-# There is no type hinting for pytest
-[[tool.mypy.overrides]]
-module = "pytest"
-ignore_missing_imports = true


### PR DESCRIPTION
This updates the MyPy configuration, adding a few new flags and making adjustments so it's clear which flags are related to `--strict` and which are other flags that I've added above and beyond that. Prototyped in [apologies PR #67](https://github.com/pronovic/apologies/pull/67).